### PR TITLE
Upgrade to Vert.x 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Stack versions -->
-    <vertx.stack.version>3.5.0</vertx.stack.version>
+    <vertx.stack.version>3.5.1</vertx.stack.version>
 
     <!-- Dependencies versions -->
     <jsoup.version>1.11.2</jsoup.version>


### PR DESCRIPTION
Vert.x version upgraded to `3.5.1` (part of [Knot.x Core #346](https://github.com/Cognifide/knotx/issues/346) )