### PR TITLE
JUnit 5 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,14 @@
 
     <!-- Test deps versions -->
     <junit.version>4.12</junit.version>
+    <junit5.version>5.2.0</junit5.version>
     <hamcrest.version>1.3</hamcrest.version>
     <powermock.version>1.6.6</powermock.version>
     <mockito.version>2.0.2-beta</mockito.version>
     <zohhak.version>1.1.1</zohhak.version>
     <hamcrest-json.version>0.2</hamcrest-json.version>
     <system-rules.version>1.16.1</system-rules.version>
+    <wiremock.version>2.18.0</wiremock.version>
 
     <maven.nexus.staging.plugin.version>1.6.7</maven.nexus.staging.plugin.version>
     <maven.gpg.plugin.version>1.5</maven.gpg.plugin.version>
@@ -228,6 +230,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>${wiremock.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.googlecode.zohhak</groupId>
         <artifactId>zohhak</artifactId>
         <version>${zohhak.version}</version>
@@ -251,6 +259,15 @@
             <artifactId>junit-dep</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <!-- JUnit5 BOM -->
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit5.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Added JUnit 5.2.0 BOM in preparation for upcoming upgrades.

WireMock is also included due to Knotx/knotx-junit5#1, which contains an extension that handles WireMock server instances.

Part of Cognifide/knotx#417.