### PR TITLE
Vert.x upgrade to 3.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Stack versions -->
-    <vertx.stack.version>3.5.1</vertx.stack.version>
+    <vertx.stack.version>3.5.3</vertx.stack.version>
 
     <!-- Dependencies versions -->
     <jsoup.version>1.11.2</jsoup.version>


### PR DESCRIPTION
Vert.x version from 3.5.1 to 3.5.3, release notes:

- https://github.com/vert-x3/wiki/wiki/3.5.2-Release-Notes
- https://github.com/vert-x3/wiki/wiki/3.5.3-Release-Notes