### PR TITLE
Add forms modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,6 @@
         <artifactId>knotx-forms-api</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-forms-adapter-http</artifactId>
-        <version>${project.version}</version>
-      </dependency>
 
       <!-- Logger -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,23 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- Knot.x Forms -->
+      <dependency>
+        <groupId>io.knotx</groupId>
+        <artifactId>knotx-forms-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.knotx</groupId>
+        <artifactId>knotx-forms-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.knotx</groupId>
+        <artifactId>knotx-forms-adapter-http</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- Logger -->
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Add forms modules to dependency manager. Changes should be applied after releasing [knotx-forms](https://github.com/Knotx/knotx-forms).