### PR TITLE
Replace HBS Knot with Template Engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,11 +133,6 @@
       </dependency>
       <dependency>
         <groupId>io.knotx</groupId>
-        <artifactId>knotx-knot-handlebars</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
         <artifactId>knotx-mocks</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -173,6 +168,23 @@
       <dependency>
         <groupId>io.knotx</groupId>
         <artifactId>knotx-forms-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <!-- Knot.x Template Engine -->
+      <dependency>
+        <groupId>io.knotx</groupId>
+        <artifactId>knotx-template-engine-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.knotx</groupId>
+        <artifactId>knotx-template-engine-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.knotx</groupId>
+        <artifactId>knotx-template-engine-handlebars</artifactId>
         <version>${project.version}</version>
       </dependency>
 


### PR DESCRIPTION
## Description
Replace HBS Knot with Template Engine

## Motivation and Context
HBS Knot is outdated implementation, it will be replaced by dedicated module [Knot.x Template Engine](https://github.com/Knotx/knotx-template-engine)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
