### PR TITLE
HTTP Action introduction, removes Data Bridge Adapters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,17 +178,7 @@
       <!-- Knot.x Data Bridge -->
       <dependency>
         <groupId>io.knotx</groupId>
-        <artifactId>knotx-databridge-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-databridge-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-databridge-adapter-http</artifactId>
+        <artifactId>knotx-action-http</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -264,19 +254,6 @@
         <artifactId>config</artifactId>
         <version>${typesafe.version}</version>
       </dependency>
-
-      <!-- DEPRECATED START -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-knot-service</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-adapter-service-http</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <!-- DEPRECATED END -->
 
       <!-- Test deps -->
       <dependency>


### PR DESCRIPTION
Introduces the HTTP Action that replaces Data Bridge Adapters.

## Motivation and Context
Fragments Handler allows to call many services (Actions) asynchronously.

## Upgrade notes (if appropriate)
Data Bridge Adapters are not supported in Knot.x 2.0.0. Fragments are processed via Actions, see https://github.com/Knotx/knotx-fragments-handler for more details.

Adapters have to be replaced with HTTP Actions. This requires changes in configuration and code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
