### PR TITLE
Remove all Knot.x Modules dependencies what causes circular dependenc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,107 +114,6 @@
         <version>${vertx.stack.version}</version>
       </dependency>
 
-      <!-- Knot.x Fragment -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-fragment-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot.x Commons -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-commons</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot.x HTTP Server -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-server-http-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-server-http-common-placeholders</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-server-http-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-splitter-html</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-assembler</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot.x Repositories -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-repository-connector-http</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-repository-connector-fs</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot Fragments Handler  -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-fragments-handler-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-fragments-handler-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot.x Data Bridge -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-action-http</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot.x Template Engine -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-template-engine-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-template-engine-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-template-engine-handlebars</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- Knot.x Stack -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-launcher</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-stack-manager</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
       <!-- Logger -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
@@ -249,19 +148,6 @@
       </dependency>
 
       <!-- Test deps -->
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-launcher</artifactId>
-        <type>test-jar</type>
-        <version>${project.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.knotx</groupId>
-        <artifactId>knotx-junit5</artifactId>
-        <version>${project.version}</version>
-        <scope>test</scope>
-      </dependency>
       <dependency><!-- JUnit 5 compatible -->
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
Knot.x Dependencies BOM should NOT contain Knot.x modules defined. This causes circular gradle dependencies in the composite build.

## Motivation and Context
[Gradle composite builds](https://docs.gradle.org/current/userguide/composite_builds.html) fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
