### PR TITLE
Vert.x upgrade to 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 All notable changes to `knotx-dependencies` will be documented in this file.
 
 ## Unreleased
-- [PR-27](https://github.com/Knotx/knotx-dependencies/pull/27) Upgrade to Vert.x `3.8.2`.
-- [PR-26](https://github.com/Knotx/knotx-dependencies/pull/26) Upgrade to Vert.x `3.8.1`.
+- [PR-27](https://github.com/Knotx/knotx-dependencies/pull/27) - Upgrade to Vert.x `3.8.2`.
+- [PR-26](https://github.com/Knotx/knotx-dependencies/pull/26) - Upgrade to Vert.x `3.8.1`.
 
 ## 2.0.0
-- [PR-23](https://github.com/Knotx/knotx-dependencies/pull/23) Upgrade to Vert.x `3.7.1`.
+- [PR-23](https://github.com/Knotx/knotx-dependencies/pull/23) - Upgrade to Vert.x `3.7.1`.
 - Add all Knot.x 2.0.0 dependencies.
 - Remove deprecated dependencies: `JUnit4`, `PowerMock`, `Hamcrest Matchers`, `Zohhak`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ All notable changes to `knotx-dependencies` will be documented in this file.
 
 ## Unreleased
 - [PR-27](https://github.com/Knotx/knotx-dependencies/pull/27) - Upgrade to Vert.x `3.8.2`.
-- [PR-26](https://github.com/Knotx/knotx-dependencies/pull/26) - Upgrade to Vert.x `3.8.1`.
 
 ## 2.0.0
 - [PR-23](https://github.com/Knotx/knotx-dependencies/pull/23) - Upgrade to Vert.x `3.7.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 All notable changes to `knotx-dependencies` will be documented in this file.
 
 ## Unreleased
-List of changes that are finished but not yet released in any final version.
-- Migrate to Vert.x `3.7.0`.
+- [PR-27](https://github.com/Knotx/knotx-dependencies/pull/27) Upgrade to Vert.x `3.8.2`.
+- [PR-26](https://github.com/Knotx/knotx-dependencies/pull/26) Upgrade to Vert.x `3.8.1`.
+
+## 2.0.0
+- [PR-23](https://github.com/Knotx/knotx-dependencies/pull/23) Upgrade to Vert.x `3.7.1`.
 - Add all Knot.x 2.0.0 dependencies.
 - Remove deprecated dependencies: `JUnit4`, `PowerMock`, `Hamcrest Matchers`, `Zohhak`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Stack versions -->
-    <vertx.stack.version>3.8.1</vertx.stack.version>
+    <vertx.stack.version>3.8.2</vertx.stack.version>
 
     <!-- Dependencies versions -->
     <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
Upgrades Vert.x from `3.8.1` to `3.8.2`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
