### PR TITLE
Upgrade to Vert.x 3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@ All notable changes to `knotx-dependencies` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-                
+- [PR-50](https://github.com/Knotx/knotx-dependencies/pull/50) - Upgrade to Vert.x `3.9.1`.
+
 ## 2.2.1
-                
+No changes.
+
 ## 2.2.0
 - [PR-33](https://github.com/Knotx/knotx-dependencies/pull/33) - Migrate from Maven to Gradle.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ publication.name=Knot.x Dependencies - BOM containing external Knot.x dependenci
 publication.description=BOM containing external Knot.x dependencies versions.
 publication.scm=scm:git:ssh://github.com:Knotx/knotx-dependencies.git
 
-vertx.stack.version=3.8.4
+vertx.stack.version=3.9.1
 commons-io.version=2.6
 commons-lang3.version=3.9
 commons-collections4.version=4.2


### PR DESCRIPTION
## Description
Upgrade Vert.x to 3.9.1

## Motivation and Context
https://github.com/Knotx/knotx-dependencies/issues/48

## Upgrade notes (if appropriate)
- Replace `setHandler` with `onComplete`: [setHandler method gets deprecated](https://github.com/vert-x3/wiki/wiki/3.9.0-Deprecations-and-breaking-changes#future-sethandler-method-gets-deprecated)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
